### PR TITLE
Reposition icons, make aquascope_serve the default run binary

### DIFF
--- a/crates/aquascope_serve/Cargo.toml
+++ b/crates/aquascope_serve/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Gavin Gray <gagray@ethz.ch>"]
 name = "aquascope_serve"
 version = "0.1.0"
 edition = "2021"
+default-run = "aquascope_serve"
 
 [dependencies]
 async-trait = "0.1.52"

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,6 +11,8 @@
 
 # production
 /build
+/entry 
+/dist
 
 # misc
 .DS_Store
@@ -28,8 +30,3 @@ yarn-error.log*
 .prettierrc.cjs
 jest.config.cjs
 tsconfig.json
-
-# Managed by Greco
-.eslintrc.js
-.prettierrc.js
-jest.config.js

--- a/frontend/src/editor.ts
+++ b/frontend/src/editor.ts
@@ -341,7 +341,9 @@ class RWDPermissions<I extends TextIco> extends WidgetType {
     let my_width = glyph_width;
     wrap.setAttribute("width", `${my_width + 10}px`);
     wrap.setAttribute("height", `${my_height}px`);
-
+    wrap.style.position = "relative";
+    wrap.style.top = `${(icons.length - 1) * 4}px`;
+    
     icons.forEach((ico_i: I, idx: number) => {
       let ico: HTMLElement = ico_i.toDom();
       let y = (idx / icons.length) * 100 + 100 / icons.length - 5;


### PR DESCRIPTION
Now if you do `cargo run` you don't need to specify `--bin aquascope_serve` by default.